### PR TITLE
fix: Update zookeeper-operator chart to reference ghcr registry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ crds: ## Generate CRDs
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image pravega/zookeeper-operator=$(TEST_IMAGE)
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/mesosphere/zookeeper-operator=$(TEST_IMAGE)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config

--- a/charts/zookeeper-operator/values.yaml
+++ b/charts/zookeeper-operator/values.yaml
@@ -8,7 +8,7 @@ global:
   # - private-registry-key
 
 image:
-  repository: pravega/zookeeper-operator
+  repository: ghcr.io/mesosphere/zookeeper-operator
   tag: 0.2.15
   pullPolicy: IfNotPresent
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: pravega/zookeeper-operator
+- name: ghcr.io/mesosphere/zookeeper-operator
   newName: testzkop/zookeeper-operator-testimages
   newTag: check

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.15
+          image: ghcr.io/mesosphere/zookeeper-operator:0.2.15
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
### Change log description

Update all Chart references to use the new `ghcr.io` registry. This PR is intended to landed after #4 is merged.

### Purpose of the change

_(e.g., Fixes #666, Closes #1234)_

### What the code does

_(Detailed description of the code changes)_

### How to verify it

_(Steps to verify that the changes are effective)_
