### PR TITLE
chore: Add manual release workflow and fix publish workflow for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: CI
 
 # on events
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
@@ -70,14 +69,27 @@ jobs:
       run: sudo make test-e2e
   publish:
     name: Publish docker image
+    runs-on:
+    - ubuntu-latest
     permissions:
       contents: read
       packages: write
-    runs-on:
-    - ubuntu-latest
     needs: build
     if: github.event_name == 'release' && github.event.action == 'created'
     steps:
+    - name: Set up Go 1.21
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.21"
+      id: go
+    - name: Set up Go for root
+      run: |
+        sudo ln -sf `which go` `sudo which go` || true
+        sudo go version
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: get go version
+      run: go version
     - name: Login to GHCR
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/d2iq-relesae-images.yaml
+++ b/.github/workflows/d2iq-relesae-images.yaml
@@ -1,0 +1,43 @@
+# workflow name
+name: Publish Release
+
+# on events
+on:
+  workflow_dispatch:
+
+# jobs to run
+jobs:
+  publish:
+    name: Publish docker image
+    runs-on:
+    - ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Set up Go 1.21
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.21"
+      id: go
+    - name: Set up Go for root
+      run: |
+        sudo ln -sf `which go` `sudo which go` || true
+        sudo go version
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: get go version
+      run: go version
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Pushing docker images
+      run: sudo make push
+    - name: Uploading binary files
+      uses: actions/upload-artifact@v2
+      with:
+        name: zookeeper-exporter
+        path: bin/zookeeper-exporter*


### PR DESCRIPTION
### Change log description

The previous PR #4 fails when publishing as seen [here](https://github.com/mesosphere/zookeeper-operator/actions/runs/7463826258/job/20312010928).

This PR adds a manual workflow to publish artifacts which can be invoked via development branch where we can land more fixes incase it breaks again.

### Purpose of the change

_(e.g., Fixes #666, Closes #1234)_

### What the code does

_(Detailed description of the code changes)_

### How to verify it

_(Steps to verify that the changes are effective)_
