### PR TITLE
fix: Update zookeeper-operator defaults for zookeeper image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ crds: ## Generate CRDs
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
-	cd config/manager && $(KUSTOMIZE) edit set image pravega/zookeeper-operator=$(TEST_IMAGE)
+	cd config/manager && $(KUSTOMIZE) edit set image ghcr.io/mesosphere/zookeeper-operator=$(TEST_IMAGE)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config

--- a/api/v1beta1/zookeepercluster_types.go
+++ b/api/v1beta1/zookeepercluster_types.go
@@ -22,11 +22,11 @@ import (
 const (
 	// DefaultZkContainerRepository is the default docker repo for the zookeeper
 	// container
-	DefaultZkContainerRepository = "pravega/zookeeper"
+	DefaultZkContainerRepository = "ghcr.io/mesosphere/zookeeper"
 
 	// DefaultZkContainerVersion is the default tag used for for the zookeeper
 	// container
-	DefaultZkContainerVersion = "0.2.15"
+	DefaultZkContainerVersion = "0.2.15-d2iq"
 
 	// DefaultZkContainerPolicy is the default container pull policy used
 	DefaultZkContainerPolicy = "Always"

--- a/api/v1beta1/zookeepercluster_types_test.go
+++ b/api/v1beta1/zookeepercluster_types_test.go
@@ -79,7 +79,7 @@ var _ = Describe("ZookeeperCluster Types", func() {
 			})
 
 			It("Checking tostring() function", func() {
-				Ω(z.Spec.Image.ToString()).To(Equal("pravega/zookeeper:0.2.15"))
+				Ω(z.Spec.Image.ToString()).To(Equal("ghcr.io/mesosphere/zookeeper:0.2.15-d2iq"))
 			})
 
 		})

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -2,8 +2,8 @@ replicas: 3
 maxUnavailableReplicas:
 
 image:
-  repository: pravega/zookeeper
-  tag: 0.2.15
+  repository: ghcr.io/mesosphere/zookeeper
+  tag: 0.2.15-d2iq
   pullPolicy: IfNotPresent
 
 triggerRollingRestart: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: pravega/zookeeper-operator:0.2.15
+          image: ghcr.io/meosphere/zookeeper-operator:0.2.15-d2iq
           ports:
           - containerPort: 60000
             name: metrics

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: zookeeper-operator
           # Replace this with the built image name
-          image: ghcr.io/meosphere/zookeeper-operator:0.2.15-d2iq
+          image: ghcr.io/mesosphere/zookeeper-operator:0.2.15-d2iq
           ports:
           - containerPort: 60000
             name: metrics

--- a/config/samples/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/config/samples/ECS/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    repository: pravega/zookeeper
-    tag: 0.2.15
+    repository: ghcr.io/mesosphere/zookeeper
+    tag: 0.2.15-d2iq
   storageType: persistence
   persistence:
     reclaimPolicy: Retain

--- a/config/samples/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
+++ b/config/samples/pravega/zookeeper_v1beta1_zookeepercluster_cr.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    repository: pravega/zookeeper
-    tag: 0.2.15
+    repository: ghcr.io/mesosphere/zookeeper
+    tag: 0.2.15-d2iq
   storageType: persistence
   persistence:
     reclaimPolicy: Delete


### PR DESCRIPTION
### Change log description

When a Zookeeper Cluster is created, it uses the upstream `pravega/zookeeper:0.2.15` image which has known vulnerabilities.

This PR changes the default for the operator to use the patched `ghcr.io/mesosphere/zookeeper:0.2.15-d2iq` image.

The defaults proposed here can still be overridden via the following when `ZookeeperClusters` are created:
```
apiVersion: "zookeeper.pravega.io/v1beta1"
kind: "ZookeeperCluster"
metadata:
  name: "example"
spec:
  replicas: 3        
  image:
    repository: ghcr.io/mesosphere/zookeeper
    tag: 0.2.15-d2iq
```
### Purpose of the change

_(e.g., Fixes #666, Closes #1234)_

### What the code does

_(Detailed description of the code changes)_

### How to verify it

_(Steps to verify that the changes are effective)_
